### PR TITLE
added option to pass netcup creds via url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Parameter | Example | Explanation
 `returnIp` | `true` / false | enables return of result if a record was changed
 `allowCreate` | true/`false` | allows creation of entries if parameter `create=true` in URL
 `restrictDomain` | true / `false` | allows admin to restrict the domain to update to a given value `domain` and/or `host`. See URL parameters for host parameter explanation
+`allowNetcupCreds` | true / `false` | allows the user to pass netcup credentials directly via the URL. URL creds will be preferred if any still exist in .env file
 
 * alternatively you can use .configure.sh to create your .env file for you (if you are on a *NIX system)
 
@@ -60,6 +61,9 @@ txt | acme-challenge-text | the content to update an existing TXT record
 force | true | ignore checking if the record needs to be updated, just do it anyways. Default: `false`
 mode | * | `case B)` If domain is your registered domain "example.com". Possible values: `*` or `both`. Default: `@`
 create | true | create all entries if none exist. e.g. will not create A if AAAA exists. Needs `allowCreate=true` in .env
+customerId | 12345 | uses the URL provided credentials instead of the ones stored in .env. Needs `allowNetcupCreds=true` in .env
+apiKey | 12345 | uses the URL provided credentials instead of the ones stored in .env. Needs `allowNetcupCreds=true` in .env
+apiPassword | 12345 | uses the URL provided credentials instead of the ones stored in .env. Needs `allowNetcupCreds=true` in .env
 
 
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,11 @@ final class Config
     /**
      * @var bool
      */
+    private $allowNetcupCreds = false;
+
+    /**
+     * @var bool
+     */
     private $restrictDomain = false;
 
     /**
@@ -88,9 +93,16 @@ final class Config
         return
             !empty($this->username) &&
             !empty($this->password) &&
-            !empty($this->apiKey) &&
-            !empty($this->apiPassword) &&
-            !empty($this->customerId) &&
+            (
+                (
+                    !empty($this->apiKey) &&
+                    !empty($this->apiPassword) &&
+                    !empty($this->customerId)
+                ) ||
+                (
+                    $this->isAllowNetcupCreds()
+                )
+            ) &&
             !empty($this->logFile);
     }
 
@@ -180,6 +192,14 @@ final class Config
     public function isRestrictDomain()
     {
         return $this->restrictDomain;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAllowNetcupCreds()
+    {
+        return $this->allowNetcupCreds;
     }
 
     /**

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -21,6 +21,21 @@ final class Handler
      */
     private $payload;
 
+    /**
+     * @var int
+     */
+    private $customerid;
+
+    /**
+     * @var string
+     */
+    private $apikey;
+
+    /**
+     * @var string
+     */
+    private $apipassword;
+
     public function __construct(array $config, array $payload)
     {
         $this->config = new Config($config);
@@ -52,6 +67,21 @@ final class Handler
             } else {
                 exit("credentials invalid\n");
             }
+        }
+
+        if ($this->config->isAllowNetcupCreds()) {
+            if ($this->payload->isValidNetcupCreds()) {
+                if ($this->config->isDebug()) {
+                    $this->doLog('received valid Netcup credentials');
+                }
+            }
+            $this->customerid = $this->payload->getCustomerId();
+            $this->apikey = $this->payload->getApiKey();
+            $this->apipassword = $this->payload->getApiPassword();
+        } else {
+            $this->customerid = $this->config->getCustomerId();
+            $this->apikey = $this->config->getApiKey();
+            $this->apipassword = $this->config->getApiPassword();
         }
 
         if (is_readable($this->config->getLogFile())) {
@@ -112,9 +142,9 @@ final class Handler
         $dnsClient = new Soap\DomainWebserviceSoapClient();
 
         $loginHandle = $dnsClient->login(
-            $this->config->getCustomerId(),
-            $this->config->getApiKey(),
-            $this->config->getApiPassword(),
+            $this->customerid,
+            $this->apikey,
+            $this->apipassword,
             $clientRequestId
         );
 
@@ -139,8 +169,8 @@ final class Handler
 
         $infoHandle = $dnsClient->infoDnsRecords(
             $updateDomainName,
-            $this->config->getCustomerId(),
-            $this->config->getApiKey(),
+            $this->customerid,
+            $this->apikey,
             $loginHandle->responsedata->apisessionid,
             $clientRequestId
         );
@@ -231,8 +261,8 @@ final class Handler
 
             $dnsClient->updateDnsRecords(
                 $updateDomainName,
-                $this->config->getCustomerId(),
-                $this->config->getApiKey(),
+                $this->customerid,
+                $this->apikey,
                 $loginHandle->responsedata->apisessionid,
                 $clientRequestId,
                 $newRecordSet
@@ -248,8 +278,8 @@ final class Handler
 
             $dnsClient->updateDnsRecords(
                 $updateDomainName,
-                $this->config->getCustomerId(),
-                $this->config->getApiKey(),
+                $this->customerid,
+                $this->apikey,
                 $loginHandle->responsedata->apisessionid,
                 $clientRequestId,
                 $recordSet
@@ -261,8 +291,8 @@ final class Handler
         }
 
         $logoutHandle = $dnsClient->logout(
-            $this->config->getCustomerId(),
-            $this->config->getApiKey(),
+            $this->customerid,
+            $this->apikey,
             $loginHandle->responsedata->apisessionid,
             $clientRequestId
         );

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -45,6 +45,21 @@ final class Payload
     private $host;
 
     /**
+     * @var int
+     */
+    private $customerId;
+
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @var string
+     */
+    private $apiPassword;
+
+    /**
      * @var bool
      */
     private $create = false;
@@ -83,6 +98,41 @@ final class Payload
                 ||
                 !empty($this->txt)
             );
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValidNetcupCreds()
+    {
+        return
+            !empty($this->customerId) &&
+            !empty($this->apiKey) &&
+            !empty($this->apiPassword);
+    }
+
+    /**
+     * @return int
+     */
+    public function getCustomerId()
+    {
+        return $this->customerId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getapiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiPassword()
+    {
+        return $this->apiPassword;
     }
 
     /**


### PR DESCRIPTION
If you set "allowNetcupCreds=true" in .env you may pass "customerId", "apiKey" and "apiPassword" directly from the URL. If all are set they will be used instead of any in the .env file. If not the ones from the .env file will be used.

This might allow anonymous usage of the installation. Now I need to figure out how to disable logging and how to allow auditing of those settings...